### PR TITLE
Fix react-bootstrap imports

### DIFF
--- a/packages/backend/src/netcat.js
+++ b/packages/backend/src/netcat.js
@@ -83,7 +83,6 @@ const serverInfo = (serverConfig) => nc(serverConfig, [
   'ServerInfo',
 ])
 
-
 const playersWithDetailsDummy = [{
   PlayerInfo: {
     UniqueId: '76561198374028403',
@@ -116,7 +115,6 @@ const playersWithDetailsDummy = [{
 },
 ]
 
-
 const inspectPlayersReal = (serverConfig, steamIds) => nc(serverConfig,
   steamIds.map((steamId) => `InspectPlayer ${steamId}`))
 
@@ -125,11 +123,19 @@ const inspectPlayersDummy = async () => playersWithDetailsDummy
 const inspectPlayers = NC_DISABLE === 'true' ? inspectPlayersDummy : inspectPlayersReal
 
 const whoIsPlayingReal = async (serverConfig) => {
-  const playerList = [...await nc(serverConfig, [
+  const playerData = await nc(serverConfig, [
     'RefreshList',
-  ])][0].PlayerList
+  ])
 
-  return playerList.map((player) => player.UniqueId)
+  if (playerData) {
+    const playerList = [...await nc(serverConfig, [
+      'RefreshList',
+    ])][0].PlayerList
+
+    return playerList.map((player) => player.UniqueId)
+  }
+
+  return []
 }
 
 const whoIsPlayingDummy = async () => playersWithDetailsDummy.map(
@@ -185,8 +191,6 @@ const switchTeam = NC_DISABLE === 'true' ? switchTeamDummy : switchTeamReal
 
 const setTeamSkin = async (serverConfig, { skinId, teamId }) => {
   const steamIds = await whoIsPlaying(serverConfig)
-
-  
 
   const playersWithDetails = [...await inspectPlayers(serverConfig, steamIds)]
 

--- a/packages/backend/src/netcat.js
+++ b/packages/backend/src/netcat.js
@@ -128,9 +128,7 @@ const whoIsPlayingReal = async (serverConfig) => {
   ])
 
   if (playerData) {
-    const playerList = [...await nc(serverConfig, [
-      'RefreshList',
-    ])][0].PlayerList
+    const playerList = playerData[0].PlayerList
 
     return playerList.map((player) => player.UniqueId)
   }

--- a/packages/frontend/src/Layout/Section.jsx
+++ b/packages/frontend/src/Layout/Section.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import Card from 'react-bootstrap/card'
+import Card from 'react-bootstrap/Card'
 
 const Section = ({ title, children }) => {
   return (

--- a/packages/frontend/src/Players/Players.jsx
+++ b/packages/frontend/src/Players/Players.jsx
@@ -2,7 +2,7 @@ import React, { useReducer, useEffect, useState, useRef, useMemo, useContext } f
 import { GlobalContext } from '../App'
 import Section from '../Layout/Section'
 import BootstrapTable from 'react-bootstrap-table-next'
-import Button from 'react-bootstrap/button'
+import Button from 'react-bootstrap/Button'
 
 function reducer(state, action) {
   switch (action.type) {

--- a/packages/frontend/src/Players/index.jsx
+++ b/packages/frontend/src/Players/index.jsx
@@ -1,5 +1,5 @@
 import React, { } from 'react'
-import Container from 'react-bootstrap/container'
+import Container from 'react-bootstrap/Container'
 import Players from './Players'
 
 const ServerAdmin = () => {

--- a/packages/frontend/src/Server/Configuration.jsx
+++ b/packages/frontend/src/Server/Configuration.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext } from 'react'
-import Form from 'react-bootstrap/form'
-import Button from 'react-bootstrap/button'
+import Form from 'react-bootstrap/Form'
+import Button from 'react-bootstrap/Button'
 import Section from '../Layout/Section'
 import { GlobalContext } from '../App'
 import { get, post } from '../utils'

--- a/packages/frontend/src/Server/Maps.jsx
+++ b/packages/frontend/src/Server/Maps.jsx
@@ -2,8 +2,8 @@ import React, { useReducer, useContext, useMemo, useEffect, useState, useRef } f
 import Section from '../Layout/Section'
 import { GlobalContext } from '../App'
 import BootstrapTable from 'react-bootstrap-table-next'
-import Button from 'react-bootstrap/button'
-import Form from 'react-bootstrap/form'
+import Button from 'react-bootstrap/Button'
+import Form from 'react-bootstrap/Form'
 import common from '@pavlov-rcon-ui/common'
 
 function reducer(state, action) {

--- a/packages/frontend/src/Server/index.jsx
+++ b/packages/frontend/src/Server/index.jsx
@@ -1,5 +1,5 @@
 import React, { } from 'react'
-import Container from 'react-bootstrap/container'
+import Container from 'react-bootstrap/Container'
 import Maps from './Maps'
 import Configuration from './Configuration'
 

--- a/packages/frontend/src/Teams/PlayersInTeam.jsx
+++ b/packages/frontend/src/Teams/PlayersInTeam.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
-import Form from 'react-bootstrap/form'
-import Button from 'react-bootstrap/button'
+import Form from 'react-bootstrap/Form'
+import Button from 'react-bootstrap/Button'
 import _differenceBy from 'lodash/differenceBy'
 import { sortPlayersByNick } from './utils'
 import styles from './playersInTeam.module.css'

--- a/packages/frontend/src/Teams/Teams.jsx
+++ b/packages/frontend/src/Teams/Teams.jsx
@@ -3,8 +3,8 @@ import React, { useReducer, useEffect, useState, useRef, useMemo, useContext } f
 import Section from '../Layout/Section'
 import PlayersInTeam from './PlayersInTeam'
 import BootstrapTable from 'react-bootstrap-table-next'
-import Button from 'react-bootstrap/button'
-import Form from 'react-bootstrap/form'
+import Button from 'react-bootstrap/Button'
+import Form from 'react-bootstrap/Form'
 import { GlobalContext } from '../App'
 import { sortPlayersByNick } from './utils'
 

--- a/packages/frontend/src/Teams/index.jsx
+++ b/packages/frontend/src/Teams/index.jsx
@@ -1,5 +1,5 @@
 import React, { } from 'react'
-import Container from 'react-bootstrap/container'
+import Container from 'react-bootstrap/Container'
 import Teams from './Teams'
 
 const ServerAdmin = () => {


### PR DESCRIPTION
I was having issues running the application, and I found that the imports didn't match up with the names of the modules within React-Bootstrap's import names, so I fixed them. Here is the error I was getting:

```
frontend: Failed to compile.
frontend: ./src/Players/Players.jsx
frontend: Module not found: Can't resolve 'react-bootstrap/button' in '~/Documents/testing/pavlov-vr-rcon/packages/frontend/src/Players'
```
This has been fixed with this PR.