### PR TITLE
Use lerna run --parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "rcon"
   ],
   "scripts": {
-    "start": "CI=true lerna run start --stream",
-    "dev": "CI=true lerna run dev --stream",
-    "dev:win": "set \"CI=true\" && lerna run dev --stream",
-    "start:win": "set \"CI=true\" && lerna run start --stream"
+    "start": "CI=true lerna run start --parallel",
+    "dev": "CI=true lerna run dev --parallel",
+    "dev:win": "set \"CI=true\" && lerna run dev --parallel",
+    "start:win": "set \"CI=true\" && lerna run start --parallel"
   },
   "devDependencies": {
     "lerna": "^3.22.1"


### PR DESCRIPTION
If --parallel isn't used, lerna defaults to the number of CPUs for the maximum number of commands run in parallel. This has the unfortunate consequence of limiting the number of parallel commands to 1 in environments where there is only one CPU, or in sandboxes where the number of CPUs can't be determined. If that happens, only the backend runs and the frontend is stuck waiting for the backend to exit.

This commit fixes the issue by lifting the concurrency limit, allowing the frontend and backend to run on parallel even if there is only one CPU available.